### PR TITLE
Adds some Vallhala hypnosprays into the normal venders

### DIFF
--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -175,6 +175,11 @@
 			/obj/item/reagent_containers/hypospray/autoinjector/dexalinplus = 10,
 			/obj/item/reagent_containers/hypospray/autoinjector/sleeptoxin = 10,
 			/obj/item/reagent_containers/hypospray/advanced = 30,
+			/obj/item/reagent_containers/hypospray/advanced/bicaridine = -1,
+			/obj/item/reagent_containers/hypospray/advanced/kelotane = -1,
+			/obj/item/reagent_containers/hypospray/advanced/tramadol = -1,
+			/obj/item/reagent_containers/hypospray/advanced/tricordrazine = -1,
+			/obj/item/reagent_containers/hypospray/advanced/dylovene = -1,
 		),
 		"Reagent Bottle" = list(
 			/obj/item/reagent_containers/glass/bottle/bicaridine = -1,


### PR DESCRIPTION
Adds some Valhalla only hypnosprays into the normal venders

## About The Pull Request

Adds Bicaridine, kelotane, tramadol, tricordrazine, and dylovene hypospray into normal NanoTrasenMed Plus

## Why It's Good For The Game

saves a bit on prep time and just more convenient than having to go out of your way and fill them up manually

## Changelog

:cl:

add: Adds Bicaridine, Kelotane, tramadol, tricordazine, and dylovene hyposprays to the NanoTrasenMed Plus vender

/:cl:
