### PR TITLE
Adds Hyposprays to the nanomed plus venders

### DIFF
--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -174,12 +174,12 @@
 		"Hypospray" = list (
 			/obj/item/reagent_containers/hypospray/autoinjector/dexalinplus = 10,
 			/obj/item/reagent_containers/hypospray/autoinjector/sleeptoxin = 10,
-			/obj/item/reagent_containers/hypospray/advanced = 30,
-			/obj/item/reagent_containers/hypospray/advanced/bicaridine = -1,
-			/obj/item/reagent_containers/hypospray/advanced/kelotane = -1,
-			/obj/item/reagent_containers/hypospray/advanced/tramadol = -1,
-			/obj/item/reagent_containers/hypospray/advanced/tricordrazine = -1,
-			/obj/item/reagent_containers/hypospray/advanced/dylovene = -1,
+			/obj/item/reagent_containers/hypospray/advanced = 5,
+			/obj/item/reagent_containers/hypospray/advanced/bicaridine = 5,
+			/obj/item/reagent_containers/hypospray/advanced/kelotane = 5,
+			/obj/item/reagent_containers/hypospray/advanced/tramadol = 5,
+			/obj/item/reagent_containers/hypospray/advanced/tricordrazine = 5,
+			/obj/item/reagent_containers/hypospray/advanced/dylovene = 5,
 		),
 		"Reagent Bottle" = list(
 			/obj/item/reagent_containers/glass/bottle/bicaridine = -1,


### PR DESCRIPTION

## About The Pull Request

Adds some hyposprays to the Nanomed Plus venders

## Why It's Good For The Game

QoL, adds bicaridine, kelotane, tramadol, tricordrazine, and dylovene hypospray to the normal nanomed plus vender I adjust the total quantity of hypos to still equal 30 in total (basicly 5 of each type plus 5 empty ones).

## Changelog


:cl:

Add: Added bicridine, kelotane, ramadol, tricordrazine, and dylovene hypospray to the shipside nanomed plus vender
balance: Reduce the total amount of empty Hyposprays from 30 to 5 (You still have 30 total hypos its just 5 of each type now)

/:cl:
